### PR TITLE
Rework accessing metadata before wait_start

### DIFF
--- a/sr/robot3/astoria.py
+++ b/sr/robot3/astoria.py
@@ -6,6 +6,7 @@ from enum import Enum
 from json import JSONDecodeError
 from pathlib import Path
 from threading import Event, Lock
+from time import sleep
 from typing import Any, ClassVar, NewType, Optional, Tuple
 
 from paho.mqtt.client import Client as MQTT
@@ -204,6 +205,8 @@ class AstoriaInterface:
         self._mqtt.subscribe("broadcast/start_button", self._process_remote_start)
         self._mqtt.subscribe("astmetad", self._process_metadata_update)
         self._mqtt.subscribe("astprocd", self._handle_astprocd_message)
+        # Wait a short time for the mount path to be updated
+        sleep(0.05)
 
     def _process_remote_start(
         self, client: MQTT, userdata: Any, msg: MQTTMessage,

--- a/sr/robot3/exceptions.py
+++ b/sr/robot3/exceptions.py
@@ -20,8 +20,7 @@ class MetadataNotReadyError(RuntimeError):
 
     def __str__(self) -> str:
         return (
-            "Metadata (e.g. zone or is_competition) can only be used after"
-            " wait_start has been called"
+            "Metadata (zone, arena and mode) can only be used after wait_start has been called"
         )
 
 

--- a/sr/robot3/robot.py
+++ b/sr/robot3/robot.py
@@ -42,7 +42,7 @@ class Robot:
     """
     __slots__ = (
         '_lock', '_metadata', '_power_board', '_motor_boards', '_servo_boards',
-        '_arduinos', '_cameras', '_mqtt', '_astoria', '_code_path', '_kch', '_raw_ports',
+        '_arduinos', '_cameras', '_mqtt', '_astoria', '_kch', '_raw_ports',
     )
 
     def __init__(
@@ -64,7 +64,6 @@ class Robot:
         logger.info(f"sr.robot3 version {__version__}")
 
         self._mqtt, self._astoria = init_astoria_mqtt()
-        self._code_path: Optional[Path] = None
 
         if manual_boards:
             self._init_power_board(manual_boards.get(PowerBoard.get_board_type(), []))
@@ -365,10 +364,7 @@ class Robot:
         :returns: path to the mountpoint of the USB code drive.
         :raises MetadataNotReadyError: If the start button has not been pressed yet
         """
-        if self._code_path is None:
-            raise MetadataNotReadyError()
-        else:
-            return self._code_path
+        return self._astoria.fetch_mount_path()
 
     @property
     def is_simulated(self) -> bool:
@@ -408,7 +404,6 @@ class Robot:
 
         # Load the latest metadata that we have received over MQTT
         self._metadata = self._astoria.fetch_current_metadata()
-        self._code_path = self._astoria.fetch_mount_path()
 
         if self._metadata.game_timeout is not None:
             timeout.kill_after_delay(self._metadata.game_timeout)

--- a/sr/robot3/robot.py
+++ b/sr/robot3/robot.py
@@ -298,22 +298,6 @@ class Robot:
         """
         return time.time()
 
-    def print_wifi_details(self) -> None:
-        """
-        Prints the current WiFi details stored in robot-settings.toml.
-
-        :raises MetadataNotReadyError: If the start button has not been pressed yet
-        """
-        if self._metadata is None:
-            raise MetadataNotReadyError()
-
-        if not self._metadata.wifi_enabled:
-            logger.warning("Could not print WiFi details - WiFi is not enabled")
-            return
-        logger.info("WiFi credentials:")
-        logger.info(f"SSID: {self._metadata.wifi_ssid}")
-        logger.info(f"Password: {self._metadata.wifi_psk}")
-
     @property
     @log_to_debug
     def arena(self) -> str:


### PR DESCRIPTION
- Allow robot.usbkey() to be called before the start button, returns the value directly set by MQTT
- Update the error message for accessing metadata, now contains the correct list of affected keys
- Remove print_wifi_details, it has been discussed that the teams can already get them from `robot_settings.toml`