### PR TITLE
Fixes from testing

### DIFF
--- a/sr/robot3/arduino.py
+++ b/sr/robot3/arduino.py
@@ -264,7 +264,7 @@ class Pin:
         self._index = index
         self._supports_analog = supports_analog
         self._disabled = disabled
-        self._mode = GPIOPinMode.INPUT_PULLUP
+        self._mode = GPIOPinMode.INPUT
 
     @property
     @log_to_debug

--- a/sr/robot3/serial_wrapper.py
+++ b/sr/robot3/serial_wrapper.py
@@ -205,6 +205,7 @@ class SerialWrapper:
             # Wait for the board to be ready to receive data
             # Certain boards will reset when the serial port is opened
             time.sleep(self.delay_after_connect)
+            self.serial.reset_input_buffer()
         except serial.SerialException:
             logger.error((
                 'Failed to connect to board '


### PR DESCRIPTION
- Discard serial data at connection. Arduinos occasionally send 0xff when booting which is breaking identification
- The default state for arduino pins is input not input pullup