### PR TITLE
Handle serial disconnections on RawSerial

### DIFF
--- a/sr/robot3/raw_serial.py
+++ b/sr/robot3/raw_serial.py
@@ -181,22 +181,22 @@ class RawSerial(Board):
         if not self._serial.is_open:
             if not self._reconnect():
                 # If the serial port cannot be opened raise an error
-                raise BoardDisconnectionError((
+                raise BoardDisconnectionError(
                     f'Connection to port {self._identity.board_type}:'
                     f'{self._identity.asset_tag} could not be established',
-                ))
+                )
         try:
             yield
         except (SerialException, OSError):
             # Serial connection failed, close the port and raise an error
             self._serial.close()
             logger.warning(
-                f'Port {self._identity.board_type}:{self._identity.asset_tag} disconnected'
+                f'Port {self._identity.board_type}:{self._identity.asset_tag} disconnected',
             )
-            raise BoardDisconnectionError((
+            raise BoardDisconnectionError(
                 f'Port {self._identity.board_type}:{self._identity.asset_tag} '
-                'disconnected during transaction'
-            ))
+                'disconnected during transaction',
+            )
 
     def _reconnect(self) -> bool:
         """
@@ -214,14 +214,14 @@ class RawSerial(Board):
             sleep(self.delay_after_connect)
             self._serial.reset_input_buffer()
         except SerialException:
-            logger.error((
+            logger.error(
                 'Failed to connect to port '
-                f'{self._identity.board_type}:{self._identity.asset_tag}'
-            ))
+                f'{self._identity.board_type}:{self._identity.asset_tag}',
+            )
             return False
 
         logger.info(
-            f'Connected to port {self._identity.board_type}: {self._identity.asset_tag}'
+            f'Connected to port {self._identity.board_type}: {self._identity.asset_tag}',
         )
         return True
 

--- a/sr/robot3/raw_serial.py
+++ b/sr/robot3/raw_serial.py
@@ -67,18 +67,11 @@ class RawSerial(Board):
             timeout=0.5,  # 500ms timeout
             do_not_open=True,
         )
-        try:
-            self._serial.open()
-        except SerialException:
-            logger.warning(
-                f'Failed to open RawSerial port {identity.board_type}:{identity.asset_tag}'
-            )
-            pass
 
         # Certain boards will reset when the serial port is opened
         # Wait for the board to be ready to receive data
         self.delay_after_connect = 2
-        sleep(self.delay_after_connect)
+        self._reconnect()
 
     @classmethod
     def _get_supported_boards(
@@ -136,9 +129,9 @@ class RawSerial(Board):
 
     @property
     @log_to_debug
-    def raw(self) -> Serial:
+    def port(self) -> Serial:
         """
-        The raw serial port.
+        The pySerial Serial object.
 
         :return: The raw serial port.
         """

--- a/sr/robot3/serial_wrapper.py
+++ b/sr/robot3/serial_wrapper.py
@@ -133,10 +133,10 @@ class SerialWrapper:
                 if not self._connect():
                     # If the serial port cannot be opened raise an error,
                     # this will be caught by the retry decorator
-                    raise BoardDisconnectionError((
+                    raise BoardDisconnectionError(
                         f'Connection to board {self.identity.board_type}:'
                         f'{self.identity.asset_tag} could not be established',
-                    ))
+                    )
 
             try:
                 if data is not None:
@@ -172,10 +172,10 @@ class SerialWrapper:
 
             if response_str.startswith('NACK'):
                 _, error_msg = response_str.split(':', maxsplit=1)
-                logger.error((
+                logger.error(
                     f'Board {self.identity.board_type}:{self.identity.asset_tag} '
                     f'returned NACK on write command: {error_msg}'
-                ))
+                )
                 raise RuntimeError(error_msg)
 
             return response_str
@@ -207,10 +207,10 @@ class SerialWrapper:
             time.sleep(self.delay_after_connect)
             self.serial.reset_input_buffer()
         except serial.SerialException:
-            logger.error((
+            logger.error(
                 'Failed to connect to board '
                 f'{self.identity.board_type}:{self.identity.asset_tag}'
-            ))
+            )
             return False
 
         logger.info(

--- a/tests/test_raw_serial.py
+++ b/tests/test_raw_serial.py
@@ -41,8 +41,10 @@ def test_invalid_properties(raw_serial: MockRawSerial) -> None:
         serial_device.invalid_property = 1
 
     assert raw_serial.serial_wrapper.mock_calls == [
-        call('test://', baudrate=115200, timeout=0.5)]
-    assert raw_serial.serial_wrapper.return_value.mock_calls == []
+        call('test://', baudrate=115200, timeout=0.5, do_not_open=True),
+        call().open(),
+    ]
+    assert raw_serial.serial_wrapper.return_value.mock_calls == [call.open()]
 
 
 def test_serial_device_discovery(monkeypatch) -> None:
@@ -102,8 +104,10 @@ def test_serial_device_discovery(monkeypatch) -> None:
             ),
         ])
         assert MockSerial.mock_calls == [
-            call('test://1', baudrate=115200, timeout=0.5),
-            call('test://3', baudrate=9600, timeout=0.5),
+            call('test://1', baudrate=115200, timeout=0.5, do_not_open=True),
+            call().open(),
+            call('test://3', baudrate=9600, timeout=0.5, do_not_open=True),
+            call().open(),
         ]
 
         assert len(serial_devices) == 2

--- a/tests/test_raw_serial.py
+++ b/tests/test_raw_serial.py
@@ -43,8 +43,12 @@ def test_invalid_properties(raw_serial: MockRawSerial) -> None:
     assert raw_serial.serial_wrapper.mock_calls == [
         call('test://', baudrate=115200, timeout=0.5, do_not_open=True),
         call().open(),
+        call().reset_input_buffer(),
     ]
-    assert raw_serial.serial_wrapper.return_value.mock_calls == [call.open()]
+    assert raw_serial.serial_wrapper.return_value.mock_calls == [
+        call.open(),
+        call.reset_input_buffer(),
+    ]
 
 
 def test_serial_device_discovery(monkeypatch) -> None:
@@ -106,8 +110,10 @@ def test_serial_device_discovery(monkeypatch) -> None:
         assert MockSerial.mock_calls == [
             call('test://1', baudrate=115200, timeout=0.5, do_not_open=True),
             call().open(),
+            call().reset_input_buffer(),
             call('test://3', baudrate=9600, timeout=0.5, do_not_open=True),
             call().open(),
+            call().reset_input_buffer(),
         ]
 
         assert len(serial_devices) == 2


### PR DESCRIPTION
On the first command after a disconnection/failure to access the port, the port is closed and a BoardDisconnectionError is raised as with Arduino-like devices this will cause the board to reset so the usercode needs notifying. If the user handles the exception, the next command will reconnect to the port and on success will perform the read/write operation requested.