### PR TITLE
Include all subpackages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "sr/robot3/_version.py"
 
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools.packages.find]
+include = ["sr.robot3", "sr.robot3.*"]
 
 [project]
 name = "sr-robot3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "sr/robot3/_version.py"
 
-[tool.setuptools]
-packages = ["sr.robot3"]
+[tool.setuptools.packages]
+find = {}
 
 [project]
 name = "sr-robot3"


### PR DESCRIPTION
We were missing `sr.robot.calibrations` and `sr.robot.simulator` in the package definition.