### PR TITLE
Ignore `setuptools-scm` file from isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ check_untyped_defs = true
 atomic = true
 balanced_wrapping = true
 known_first_party = "sr.robot3"
+skip_gitignore = true
 
 # hanging grid grouped indent style wrapping
 multi_line_output = 5


### PR DESCRIPTION
Seems `isort` is trying to fix the `setuptools-scm` file - which it shouldn't.

This might also be solved by porting to `ruff`, but that's a larger change and this is blocking merging.